### PR TITLE
Fix bug of SubDataRef

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -22,6 +22,15 @@ def test_xdata():
     except AssertionError as _:
         print("test == assertion pass")
 
+    # test SubDataRef
+    body = XData(200, XData.InOut)
+    shadow_clones = [body.SubDataRef(i * 6, 6) for i in range(33)]
+    for i in range(len(shadow_clones)):
+        s = shadow_clones[i]
+        s.value = 0b101011
+        assert body.value == (0b101011 << (i * 6))
+        s.value = 0
+
     data = XData(64, XData.InOut)
     data.value = -1
     data[0] = 0


### PR DESCRIPTION
In the following code:

```python
x = XData(200, XData.InOut)
x.SetWriteMode(XData.Imme)

r = x.SubDataRef(90, 6)
r.SetWriteMode(XData.Imme)
r.value = 1
```

The expected result for `r` is 1, and the expected result for `x` is 0x40000000000000000000000, but the actual results for both `r` and `x `are 0.

After the repair, it can be ensured that the test code runs correctly.

