### PR TITLE
fix java long not support for 33 bits and more

### DIFF
--- a/swig/java/java.i
+++ b/swig/java/java.i
@@ -106,11 +106,7 @@ import java.util.List;
   }
 
   public void Set(long data) {
-    if(data < 0){
-      this.Set(BigInteger.valueOf(data));
-    }else{
-      this.Setl(data);
-    }
+    this.Set(BigInteger.valueOf(data));
   }
 
 %}

--- a/swig/scala/scala.i
+++ b/swig/scala/scala.i
@@ -106,11 +106,7 @@ import java.util.List;
   }
 
   public void Set(long data) {
-    if(data < 0){
-      this.Set(BigInteger.valueOf(data));
-    }else{
-      this.Setl(data);
-    }
+    this.Set(BigInteger.valueOf(data));
   }
 
 %}


### PR DESCRIPTION
修复了java和scala上调用Set(long)只会设置低32位的问题，使用BigInteger存储这两种语言的long